### PR TITLE
 ft: Add receptionist & doctor routes for patient filtering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "dotenv": "^16.4.5",
         "express": "^4.21.1",
         "jsonwebtoken": "^9.0.2",
+        "moment": "^2.30.1",
         "mongoose": "^8.8.2"
       },
       "devDependencies": {
@@ -21,6 +22,7 @@
         "@types/cors": "^2.8.17",
         "@types/express": "^5.0.0",
         "@types/jsonwebtoken": "^9.0.7",
+        "@types/moment": "^2.13.0",
         "@types/mongoose": "^5.11.97",
         "@types/node": "^22.9.3",
         "@types/nodemon": "^1.19.6",
@@ -498,6 +500,16 @@
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
       "dev": true
+    },
+    "node_modules/@types/moment": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@types/moment/-/moment-2.13.0.tgz",
+      "integrity": "sha512-DyuyYGpV6r+4Z1bUznLi/Y7HpGn4iQ4IVcGn8zrr1P4KotKLdH0sbK1TFR6RGyX6B+G8u83wCzL+bpawKU/hdQ==",
+      "deprecated": "This is a stub types definition for Moment (https://github.com/moment/moment). Moment provides its own type definitions, so you don't need @types/moment installed!",
+      "dev": true,
+      "dependencies": {
+        "moment": "*"
+      }
     },
     "node_modules/@types/mongoose": {
       "version": "5.11.97",
@@ -2577,6 +2589,14 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/mongodb": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@types/cors": "^2.8.17",
     "@types/express": "^5.0.0",
     "@types/jsonwebtoken": "^9.0.7",
+    "@types/moment": "^2.13.0",
     "@types/mongoose": "^5.11.97",
     "@types/node": "^22.9.3",
     "@types/nodemon": "^1.19.6",
@@ -38,6 +39,7 @@
     "dotenv": "^16.4.5",
     "express": "^4.21.1",
     "jsonwebtoken": "^9.0.2",
+    "moment": "^2.30.1",
     "mongoose": "^8.8.2"
   }
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -5,6 +5,7 @@ import dotenv from "dotenv";
 import errorHandler from "./middleware/errorMiddleware";
 import patientRoutes from "./routes/patientRoutes";
 import doctorRoutes from "./routes/doctor"
+import adminRoutes  from "./routes/adminRoutes"
 
 import cors from "cors";
 
@@ -37,6 +38,7 @@ app.use(errorHandler);
 app.use("/api", routes);
 app.use("/api/patients", patientRoutes);
 app.use("/api/doctor", doctorRoutes);
+app.use("/api/admin", adminRoutes);
 
 
 const PORT = process.env.PORT || 3000;

--- a/src/models/patient.ts
+++ b/src/models/patient.ts
@@ -14,6 +14,8 @@ export interface IPatient extends Document {
   motherName?: string;
   sector?: string;
   insurance?: string;
+  editReason:string;
+  appointmentLocation:string;
 }
 
 const PatientSchema = new Schema<IPatient>(
@@ -42,6 +44,11 @@ const PatientSchema = new Schema<IPatient>(
       type: mongoose.Schema.Types.ObjectId,
       ref: "User",
       required: true,
+    },
+    editReason: {
+      type: String,
+      required: false,
+      default:null,
     },
     status: {
       type: String,
@@ -73,6 +80,12 @@ const PatientSchema = new Schema<IPatient>(
       type: String,
       required: false,
     },
+    appointmentLocation: {
+      type: String,
+      required: false,
+      default:"Nyarugenge",
+    },
+    
   },
   {
     timestamps: true,

--- a/src/models/patient.ts
+++ b/src/models/patient.ts
@@ -32,7 +32,7 @@ const PatientSchema = new Schema<IPatient>(
     },
     dateOfAppointment: { 
       type: Date,
-      required: true,
+      required: false,
     },
     reason: {
       type: String,

--- a/src/models/rotationnn.ts
+++ b/src/models/rotationnn.ts
@@ -1,0 +1,10 @@
+import mongoose from "mongoose";
+
+const rotationSchema = new mongoose.Schema({
+  key: { type: String, required: true, unique: true },
+  value: { type: Number, required: true },
+});
+
+const Rotation = mongoose.model("Rotation", rotationSchema);
+
+export default Rotation;

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -5,6 +5,7 @@ import bcrypt from "bcrypt";
 export enum UserRole {
   DOCTOR = "doctor",
   RECEPTIONIST = "receptionist",
+  ADMIN = "admin"
 }
 
 

--- a/src/routes/adminRoutes.ts
+++ b/src/routes/adminRoutes.ts
@@ -1,0 +1,185 @@
+import express from 'express';
+import { protect, checkRole } from '../middleware/authMiddleware';
+import Patient from '../models/patient';
+import User from '../models/user';
+import moment from 'moment';
+import mongoose from 'mongoose';
+
+const router = express.Router();
+
+router.get(
+  '/dashboard-stats-admin',
+  protect,
+  async (req, res): Promise<void> => {
+    try {
+      const userRole = req.user?.role;
+
+      if (userRole !== 'admin') {
+        res.status(403).json({
+          message: 'Access denied. Only admins can access this data.',
+        });
+      }
+
+      const startDate = req.query.startDate
+        ? moment(req.query.startDate as string)
+            .startOf('day')
+            .toDate()
+        : moment().startOf('day').toDate();
+
+      const endDate = req.query.endDate
+        ? moment(req.query.endDate as string)
+            .endOf('day')
+            .toDate()
+        : moment().endOf('day').toDate();
+
+      const [totalAppointments, pendingAppointments, completeAppointments] =
+        await Promise.all([
+          Patient.countDocuments({
+            dateAssigned: { $gte: startDate, $lte: endDate },
+          }),
+          Patient.countDocuments({
+            status: 'pending',
+            dateAssigned: { $gte: startDate, $lte: endDate },
+          }),
+          Patient.countDocuments({
+            status: 'complete',
+            dateAssigned: { $gte: startDate, $lte: endDate },
+          }),
+        ]);
+
+      res.status(200).json({
+        totalPatients: totalAppointments,
+        pendingPatients: pendingAppointments,
+        completePatients: completeAppointments,
+        timeRange: { startDate, endDate },
+      });
+    } catch (error: any) {
+      res.status(500).json({
+        message: 'Error fetching dashboard statistics',
+        error: error.message,
+      });
+    }
+  },
+);
+
+router.get(
+  '/filter-by-appointment-admin',
+  protect,
+  async (req, res): Promise<void> => {
+    const { startDate, endDate, doctorId, status } = req.query;
+
+    try {
+      const userRole = req.user?.role;
+
+      if (userRole !== 'admin') {
+        res.status(403).json({
+          message:
+            'Access denied. Only admins can filter patients by appointment.',
+        });
+      }
+
+      const start = startDate
+        ? moment(startDate as string)
+            .startOf('day')
+            .toDate()
+        : moment().startOf('day').toDate();
+
+      const end = endDate
+        ? moment(endDate as string)
+            .endOf('day')
+            .toDate()
+        : moment().endOf('day').toDate();
+
+      const dateFilter: any = {
+        dateAssigned: { $gte: start, $lte: end },
+      };
+
+      const patients = await Patient.find(dateFilter)
+        .populate('doctorAssigned', 'name')
+        .populate('receptionist', 'name');
+
+      res.status(200).json({
+        message: 'Filtered patients fetched successfully',
+        patients,
+      });
+    } catch (error: any) {
+      res
+        .status(500)
+        .json({ message: 'Error filtering patients', error: error.message });
+    }
+  },
+);
+
+router.get('/doctors-with-stats', protect, async (req, res): Promise<void> => {
+  const { startDate, endDate } = req.query;
+
+  try {
+    const userRole = req.user?.role;
+
+    if (userRole !== 'admin') {
+      res
+        .status(403)
+        .json({ message: 'Access denied. Only admins can view this data.' });
+      return;
+    }
+
+    const start = startDate
+      ? moment(startDate as string)
+          .startOf('day')
+          .toDate()
+      : moment().startOf('day').toDate();
+
+    const end = endDate
+      ? moment(endDate as string)
+          .endOf('day')
+          .toDate()
+      : moment().endOf('day').toDate();
+
+    const doctors = await User.find({ role: 'doctor' });
+
+    const doctorsWithStats = await Promise.all(
+      doctors.map(async (doctor) => {
+        const [totalPatients, pendingPatients, completePatients] =
+          await Promise.all([
+            Patient.countDocuments({
+              doctorAssigned: doctor._id,
+              dateOfAppointment: { $gte: start, $lte: end },
+            }),
+            Patient.countDocuments({
+              doctorAssigned: doctor._id,
+              dateOfAppointment: { $gte: start, $lte: end },
+              status: 'pending',
+            }),
+            Patient.countDocuments({
+              doctorAssigned: doctor._id,
+              dateOfAppointment: { $gte: start, $lte: end },
+              status: 'complete',
+            }),
+          ]);
+
+        return {
+          doctorId: doctor._id,
+          name: doctor.name,
+          phoneNumber: doctor.phoneNumber,
+          totalPatients,
+          pendingPatients,
+          completePatients,
+        };
+      }),
+    );
+
+    res.status(200).json({
+      message: 'Admins and their patient stats fetched successfully',
+      admins: doctorsWithStats,
+    });
+  } catch (error: any) {
+    res
+      .status(500)
+      .json({
+        message: 'Error fetching admins and their stats',
+        error: error.message,
+      });
+  }
+});
+
+export default router;

--- a/src/routes/patientRoutes.ts
+++ b/src/routes/patientRoutes.ts
@@ -2,6 +2,7 @@ import express from "express";
 import { protect, checkRole } from "../middleware/authMiddleware";
 import Patient from "../models/patient";
 import User from "../models/user";
+import moment from 'moment';
 import { startOfDay, endOfDay } from "date-fns";
 
 const router = express.Router();
@@ -363,7 +364,203 @@ router.get(
   }
 );
 
+router.get(
+  "/dashboard-stats-doc",
+  protect,
+  async (req, res): Promise<void> => {
+    try {
+      const userRole = req.user?.role;
+      const userId = req.user?.id;
+
+      const startDate = req.query.startDate 
+      ? moment(req.query.startDate as string).startOf('day').toDate() 
+      : moment().startOf('day').toDate();
+    
+    const endDate = req.query.endDate 
+      ? moment(req.query.endDate as string).endOf('day').toDate() 
+      : moment().endOf('day').toDate();
+
+      if (userRole === "doctor") {
+        const [totalAssigned, pendingAssigned, completeAssigned] = await Promise.all([
+          Patient.countDocuments({
+            doctorAssigned: userId,
+            dateOfAppointment: {
+              $gte: startDate,
+              $lte: endDate,
+            }
+          }),
+          Patient.countDocuments({
+            doctorAssigned: userId,
+            status: "pending",
+            dateOfAppointment: {
+              $gte: startDate,
+              $lte: endDate,
+            }
+          }),
+          Patient.countDocuments({
+            doctorAssigned: userId,
+            status: "complete",
+            dateOfAppointment: {
+              $gte: startDate,
+              $lte: endDate,
+            }
+          }),
+        ]);
+
+        res.status(200).json({
+          totalPatients: totalAssigned,
+          pendingPatients: pendingAssigned,
+          completePatients: completeAssigned,
+          timeRange: { startDate, endDate },
+        });
+      } else {
+        res.status(403).json({ message: "Access denied. Only doctors can access this data." });
+      }
+    } catch (error: any) {
+      res.status(500).json({ message: "Error fetching dashboard statistics", error: error.message });
+    }
+  }
+);
 
 
+router.get(
+  "/filter-by-appointment-doc",
+  protect,
+  async (req, res): Promise<void> => {
+    const { startDate, endDate } = req.query;
+
+    try {
+      const userRole = req.user?.role;
+      const userId = req.user?.id;
+
+      if (userRole !== "doctor") {
+        res.status(403).json({ message: "Access denied. Only doctors can filter patients by appointment." });
+        return;
+      }
+
+      const start = startDate 
+        ? moment(startDate as string).startOf('day').toDate()
+        : moment().startOf('day').toDate();
+        
+      const end = endDate 
+        ? moment(endDate as string).endOf('day').toDate()
+        : moment().endOf('day').toDate();
+
+      const dateFilter = {
+        doctorAssigned: userId,
+        dateOfAppointment: {
+          $gte: start,
+          $lte: end,
+        },
+      };
+
+      const patients = await Patient.find(dateFilter)
+        .populate("doctorAssigned", "name")
+        .populate("receptionist", "name");
+
+      res.status(200).json({
+        message: "Filtered patients fetched successfully",
+        patients,
+      });
+    } catch (error: any) {
+      res.status(500).json({ message: "Error filtering patients", error: error.message });
+    }
+  }
+);
+
+router.get(
+  "/dashboard-stats-receptionist",
+  protect,
+  async (req, res): Promise<void> => {
+    try {
+      const userRole = req.user?.role;
+      const userId = req.user?.id;
+
+      const startDate = req.query.startDate
+        ? moment(req.query.startDate as string).startOf('day').toDate()
+        : moment().startOf('day').toDate();
+
+      const endDate = req.query.endDate
+        ? moment(req.query.endDate as string).endOf('day').toDate()
+        : moment().endOf('day').toDate();
+
+      if (userRole !== "receptionist") {
+        res.status(403).json({ message: "Access denied. Only receptionists can access this data." });
+      }
+
+      const assignedReceptionistFilter = { receptionist: userId };
+
+      const [totalAssigned, pendingAssigned, completeAssigned] = await Promise.all([
+        Patient.countDocuments({
+          dateAssigned: { $gte: startDate, $lte: endDate },
+          ...assignedReceptionistFilter
+        }),
+        Patient.countDocuments({
+          status: "pending",
+          dateAssigned: { $gte: startDate, $lte: endDate },
+          ...assignedReceptionistFilter
+        }),
+        Patient.countDocuments({
+          status: "complete",
+          dateAssigned: { $gte: startDate, $lte: endDate },
+          ...assignedReceptionistFilter
+        }),
+      ]);
+
+      res.status(200).json({
+        totalPatients: totalAssigned,
+        pendingPatients: pendingAssigned,
+        completePatients: completeAssigned,
+        timeRange: { startDate, endDate },
+      });
+
+    } catch (error: any) {
+      res.status(500).json({ message: "Error fetching dashboard statistics", error: error.message });
+    }
+  }
+);
+
+
+router.get(
+  "/filter-by-appointment-receptionist",
+  protect,
+  async (req, res): Promise<void> => {
+    const { startDate, endDate, doctorId, status } = req.query;
+
+    try {
+      const userRole = req.user?.role;
+      const userId = req.user?.id;
+
+      if (userRole !== "receptionist") {
+        res.status(403).json({ message: "Access denied. Only receptionists can filter patients by appointment." });
+      }
+
+      const start = startDate
+        ? moment(startDate as string).startOf('day').toDate()
+        : moment().startOf('day').toDate();
+
+      const end = endDate
+        ? moment(endDate as string).endOf('day').toDate()
+        : moment().endOf('day').toDate();
+
+      const dateFilter: any = {
+        dateAssigned: { $gte: start, $lte: end },
+        receptionist: userId,
+      };
+
+      const patients = await Patient.find(dateFilter)
+        .populate("doctorAssigned", "name")
+        .populate("receptionist", "name");
+
+      res.status(200).json({
+        message: "Filtered patients fetched successfully",
+        patients,
+      });
+
+    } catch (error: any) {
+      res.status(500).json({ message: "Error filtering patients", error: error.message });
+    }
+  }
+);
 
 export default router;

--- a/src/seeds/seeder.ts
+++ b/src/seeds/seeder.ts
@@ -14,28 +14,28 @@ const seedUsers = async () => {
       {
         name: "UMULISA Alice",
         email: "umulisaalice@gmail.com",
-        password: "medidesk@123",
+        password: "amatamamam",
         phoneNumber: "098-765-4371",
         role: UserRole.RECEPTIONIST,
       },
       {
         name: "UGIRUMURENGERA Blaise",
         email: "ugblaise@gmail.com",
-        password: "medidesk@123",
+        password: "amatamamam",
         phoneNumber: "098-765-4361",
         role: UserRole.RECEPTIONIST,
       },
       {
         name: "NSHIMIYIMANA Jean Claude",
         email: "jeanclaudensh@gmail.com",
-        password: "medidesk@123",
+        password: "amatamamam",
         phoneNumber: "098-765-4341",
         role: UserRole.RECEPTIONIST,
       },
       {
         name: "OMBENI Vedaste",
         email: "ombenivedaste@gmail.com",
-        password: "medidesk@123",
+        password: "amatamamam",
         phoneNumber: "098-765-4301",
         role: UserRole.RECEPTIONIST,
       },
@@ -44,7 +44,7 @@ const seedUsers = async () => {
       {
         name: "Alice Johnson",
         email: "alice.johnson@example.com",
-        password: "medidesk@123",
+        password: "amatamamam",
         phoneNumber: "123-456-7890",
         role: UserRole.DOCTOR,
         status: "active", 
@@ -52,7 +52,7 @@ const seedUsers = async () => {
       {
         name: "Charlie Brown",
         email: "charlie.brown@example.com",
-        password: "medidesk@123",
+        password: "amatamamam",
         phoneNumber: "555-555-5555",
         role: UserRole.DOCTOR,
         status: "active",
@@ -62,7 +62,7 @@ const seedUsers = async () => {
       {
         name: "Dr. Eugene Lambert",
         email: "eugene.lambert@example.com",
-        password: "medidesk@123",
+        password: "amatamamam",
         phoneNumber: "987-654-3210",
         role: UserRole.DOCTOR,
         status: "not available", 
@@ -72,7 +72,7 @@ const seedUsers = async () => {
       {
         name: "Dr. Clara Wilson",
         email: "clara.wilson@example.com",
-        password: "medidesk@123",
+        password: "amatamamam",
         phoneNumber: "111-222-3333",
         role: UserRole.DOCTOR,
         status: "active",
@@ -80,7 +80,7 @@ const seedUsers = async () => {
       {
         name: "Dr. Olivia Martinez",
         email: "olivia.martinez@example.com",
-        password: "medidesk@123",
+        password: "amatamamam",
         phoneNumber: "222-333-4444",
         role: UserRole.DOCTOR,
         status: "active",
@@ -88,7 +88,7 @@ const seedUsers = async () => {
       {
         name: "Receptionist Jane Doe",
         email: "jane.doe@example.com",
-        password: "medidesk@123",
+        password: "amatamamam",
         phoneNumber: "333-444-5555",
         role: UserRole.RECEPTIONIST,
       },

--- a/src/utils/rotation.ts
+++ b/src/utils/rotation.ts
@@ -1,0 +1,67 @@
+import Rotation from '../models/rotationnn';
+import mongoose, { ObjectId } from 'mongoose';
+
+// Hardcoded array of doctors in the specified order
+// const doctors = [
+//   new mongoose.Types.ObjectId('674b1ab812b75d23e409bdd6'),
+//   'Justin',
+//   'Sandeep R',
+//   'Justin',
+//   'Danilo',
+//   'Sandeep N',
+//   'Valens',
+//   'Justin R',
+//   'Muhamedi',
+//   'Valens',
+//   'Justin R',
+//   'Valens',
+//   'Sandeep N',
+//   'Muhamedi',
+//   'Sandeep R',
+//   'Justin',
+//   'Valens',
+// ];
+
+const doctors = [
+  new mongoose.Types.ObjectId('674b1ab812b75d23e409bdd6'),
+  new mongoose.Types.ObjectId('674b1ab812b75d23e409bdd7'),
+  new mongoose.Types.ObjectId('674b1ab812b75d23e409bdd8'),
+  new mongoose.Types.ObjectId('674b1ab812b75d23e409bdd6'),
+  new mongoose.Types.ObjectId('674b1ab812b75d23e409bdd7'),
+  new mongoose.Types.ObjectId('674b1ab812b75d23e409bdd9'),
+  new mongoose.Types.ObjectId('674b1ab812b75d23e409bdd6'),
+  new mongoose.Types.ObjectId('674b1ab812b75d23e409bdda'),
+  new mongoose.Types.ObjectId('674b1ab812b75d23e409bdd7'),
+  new mongoose.Types.ObjectId('674b1ab812b75d23e409bdd9'),
+  new mongoose.Types.ObjectId('674b1ab812b75d23e409bdd7'),
+  new mongoose.Types.ObjectId('674b1ab812b75d23e409bdd9'),
+  new mongoose.Types.ObjectId('674b1ab812b75d23e409bdd6'),
+  new mongoose.Types.ObjectId('674b1ab812b75d23e409bdda'),
+  new mongoose.Types.ObjectId('674b1ab812b75d23e409bdd6'),
+  new mongoose.Types.ObjectId('674b1ab812b75d23e409bdd7'),
+  new mongoose.Types.ObjectId('674b1ab812b75d23e409bdd9'),
+];
+
+// Function to get the current doctor index
+async function getCurrentDoctorIndex() {
+  const rotation = await Rotation.findOne({ key: 'currentDoctorIndex' });
+  return rotation ? rotation.value : 0;
+}
+
+// Function to update the current doctor index
+async function updateCurrentDoctorIndex(index: any) {
+  await Rotation.updateOne(
+    { key: 'currentDoctorIndex' },
+    { value: index },
+    { upsert: true },
+  );
+}
+
+// Function to assign the next doctor
+export const assignDoctor = async (): Promise<any> => {
+  const currentIndex = await getCurrentDoctorIndex();
+  const assignedDoctor = doctors[currentIndex];
+  const nextIndex = (currentIndex + 1) % doctors.length;
+  await updateCurrentDoctorIndex(nextIndex);
+  return assignedDoctor;
+};


### PR DESCRIPTION
This PR introduces new routes for both receptionists and doctors to manage and filter patient data:

### /dashboard-stats-receptionist:

Fetches patient statistics (total, pending, complete) based on the dateAssigned and the receptionist who assigned the patients.
### /filter-by-appointment-receptionist:

Filters patients assigned by the logged-in receptionist within a specified date range, with optional filters for doctor and status.
### /dashboard-stats-doc:

Fetches patient statistics (total, pending, complete) for a specific doctor based on the dateOfAppointment.
### /filter-by-appointment-doc:

Filters patients assigned to a specific doctor within a specified date range, with optional filters for status.
These routes ensure that receptionists and doctors can access and filter patient data relevant to their roles, while maintaining data access restrictions based on the user's role.